### PR TITLE
Sprite Renderer

### DIFF
--- a/CMGT/CMGT.vcxproj
+++ b/CMGT/CMGT.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClInclude Include="Application.h" />
     <ClInclude Include="Component.h" />
+    <ClInclude Include="Debug.h" />
     <ClInclude Include="Event.h" />
     <ClInclude Include="GameObject.h" />
     <ClInclude Include="Object.h" />
@@ -28,9 +29,12 @@
     <ClInclude Include="Scene.h" />
     <ClInclude Include="ObjectHandler.h" />
     <ClInclude Include="SceneManager.h" />
+    <ClInclude Include="SpriteRenderer.h" />
+    <ClInclude Include="Texture2D.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Application.cpp" />
+    <ClCompile Include="Debug.cpp" />
     <ClCompile Include="Graphics.cpp" />
     <ClCompile Include="Main.h" />
     <ClCompile Include="GameObject.cpp" />
@@ -129,6 +133,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>C:\SFML-2.5.1\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -146,6 +151,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>C:\SFML-2.5.1\include</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/CMGT/CMGT.vcxproj.filters
+++ b/CMGT/CMGT.vcxproj.filters
@@ -20,6 +20,18 @@
     <Filter Include="IEngine\SceneManagement">
       <UniqueIdentifier>{93ecffe1-f387-4d7b-8e20-38d8a0f31831}</UniqueIdentifier>
     </Filter>
+    <Filter Include="IEngine\Components">
+      <UniqueIdentifier>{7db909d3-ad37-4fca-a40b-3c16cd6b61c8}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IEngine\Components\Graphics">
+      <UniqueIdentifier>{f113919a-f544-4071-ae8b-6259475c478e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IEngine\DataTypes">
+      <UniqueIdentifier>{205f78b4-9b52-42b7-a9b6-b93bd5f9c661}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="IEngine\Utils">
+      <UniqueIdentifier>{96e66f8c-d901-4055-b694-f76665325b8b}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Object.cpp">
@@ -50,6 +62,9 @@
     <ClCompile Include="SceneManager.cpp">
       <Filter>IEngine\SceneManagement</Filter>
     </ClCompile>
+    <ClCompile Include="Debug.cpp">
+      <Filter>IEngine\Utils</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Object.h">
@@ -76,6 +91,15 @@
     </ClInclude>
     <ClInclude Include="SceneManager.h">
       <Filter>IEngine\SceneManagement</Filter>
+    </ClInclude>
+    <ClInclude Include="SpriteRenderer.h">
+      <Filter>IEngine\Components\Graphics</Filter>
+    </ClInclude>
+    <ClInclude Include="Texture2D.h">
+      <Filter>IEngine\DataTypes</Filter>
+    </ClInclude>
+    <ClInclude Include="Debug.h">
+      <Filter>IEngine\Utils</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/CMGT/CMGT.vcxproj.user
+++ b/CMGT/CMGT.vcxproj.user
@@ -3,10 +3,12 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LocalDebuggerEnvironment>PATH=C:\SFML-2.5.1\bin</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)Assets</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LocalDebuggerEnvironment>PATH=C:\SFML-2.5.1\bin</LocalDebuggerEnvironment>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
+    <LocalDebuggerWorkingDirectory>$(SolutionDir)Assets</LocalDebuggerWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <ShowAllFiles>false</ShowAllFiles>

--- a/CMGT/Debug.cpp
+++ b/CMGT/Debug.cpp
@@ -1,0 +1,17 @@
+#pragma once
+#include "Debug.h"
+#include <iostream>
+
+#define WHITE   "\033[0m"
+#define RED     "\033[31m"
+#define YELLOW  "\033[33m"
+
+
+void Debug::Log(string message)			{ Log(" > " + message, WHITE); }
+void Debug::LogError(string message)	{ Log("[ERROR] " + message, RED); }
+void Debug::LogWarning(string message)	{ Log("[WARNING] " + message, YELLOW); }
+
+void Debug::Log(string message, string colorCode)
+{
+	std::cout << colorCode << message << "\n";
+}

--- a/CMGT/Debug.h
+++ b/CMGT/Debug.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <string>
+
+using string = std::string;
+
+
+class Debug
+{
+public:
+	static void Log(string message);
+	static void LogError(string message);
+	static void LogWarning(string message);
+
+	static void Log(string message, string colorCode);
+};

--- a/CMGT/Graphics.cpp
+++ b/CMGT/Graphics.cpp
@@ -1,4 +1,20 @@
 #pragma once
 #include "Graphics.h"
 
-sf::Window Graphics::_window(sf::VideoMode(800, 600), "IEngine");
+sf::RenderWindow Graphics::_window(sf::VideoMode(800, 600), "IEngine"); 
+std::vector<sf::Sprite*> Graphics::_renderQueue;
+
+void Graphics::Render()
+{
+	_window.clear();
+	for (int i = 0; i < _renderQueue.size(); i++)
+		_window.draw(*_renderQueue[i]);
+	_window.display();
+	_renderQueue.clear();
+}
+
+
+void Graphics::QueueForRendering(sf::Sprite* sprite)
+{
+	_renderQueue.push_back(sprite);
+}

--- a/CMGT/Graphics.h
+++ b/CMGT/Graphics.h
@@ -2,9 +2,16 @@
 
 #include <SFML/Window.hpp>
 #include <SFML/Graphics.hpp>
+#include <vector>
 
 class Graphics
 {
 private:
-	static sf::Window _window;
+	static sf::RenderWindow _window;
+
+	static std::vector<sf::Sprite*> _renderQueue;
+
+public:
+	static void Render();
+	static void QueueForRendering(sf::Sprite* sprite);
 };

--- a/CMGT/Object.h
+++ b/CMGT/Object.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <type_traits>
 #include <typeinfo>
+#include "Debug.h"
 
 template<typename T>
 class ControlBlock;

--- a/CMGT/ObjectHandler.cpp
+++ b/CMGT/ObjectHandler.cpp
@@ -21,6 +21,11 @@ void ObjectHandler::LateUpdateAll()
     onLateUpdate.Invoke();
 }
 
+void ObjectHandler::RenderAll()
+{
+    onRender.Invoke();
+}
+
 void ObjectHandler::DrawGizmosAll()
 {
     onDrawGizmos.Invoke();

--- a/CMGT/ObjectHandler.h
+++ b/CMGT/ObjectHandler.h
@@ -4,10 +4,10 @@
 #include <algorithm>
 #include <type_traits>
 #include <unordered_map>
-#include <string>
 
 #include "Event.h"
 #include "Object.h";
+#include "Debug.h";
 
 
 /// <summary>
@@ -25,6 +25,7 @@ public:
     void FixedUpdateAll();
     void UpdateAll();
     void LateUpdateAll();
+    void RenderAll();
     void DrawGizmosAll();
 
 private:
@@ -34,6 +35,7 @@ private:
     Event<> onFixedUpdate;
     Event<> onUpdate;
     Event<> onLateUpdate;
+    Event<> onRender;
     Event<> onDrawGizmos;
 };
 
@@ -74,6 +76,7 @@ DEFINE_HAS_METHOD(Update);
 DEFINE_HAS_METHOD(Start);
 DEFINE_HAS_METHOD(FixedUpdate);
 DEFINE_HAS_METHOD(LateUpdate);
+DEFINE_HAS_METHOD(OnRender);
 DEFINE_HAS_METHOD(DrawGizmos);
 
 /*
@@ -85,7 +88,8 @@ DEFINE_HAS_METHOD(DrawGizmos);
 #define REGISTER_METHOD(MethodName, EventName)                           \
     if constexpr (has_##MethodName<T>::value) {                          \
         auto MethodName##_Delegate = [component](auto&&... args) {       \
-            component->MethodName(std::forward<decltype(args)>(args)...);\
+            try { component->MethodName(std::forward<decltype(args)>(args)...); } \
+            catch (const std::exception& e) { Debug::Log(string(e.what())); } \
         };                                                               \
         EventName.AddListener(MethodName##_Delegate);                   \
         _registeredDelegates[#MethodName] = MethodName##_Delegate;      \
@@ -107,6 +111,7 @@ void ObjectHandler::Register(T* component)
     REGISTER_METHOD(FixedUpdate, onFixedUpdate);
     REGISTER_METHOD(Update, onUpdate);
     REGISTER_METHOD(LateUpdate, onLateUpdate);
+    REGISTER_METHOD(OnRender, onRender);
     REGISTER_METHOD(DrawGizmos, onDrawGizmos);
 }
 
@@ -118,6 +123,7 @@ void ObjectHandler::Unregister(T* component)
     UNREGISTER_METHOD(FixedUpdate, onFixedUpdate);
     UNREGISTER_METHOD(Update, onUpdate);
     UNREGISTER_METHOD(LateUpdate, onLateUpdate);
+    UNREGISTER_METHOD(OnRender, onRender);
     UNREGISTER_METHOD(DrawGizmos, onDrawGizmos);
 
 }

--- a/CMGT/Pointer.h
+++ b/CMGT/Pointer.h
@@ -115,7 +115,7 @@ public:
 
     T* operator->() const
     {
-        if (!_controlBlock || !_controlBlock->object)
+        if (_controlBlock == nullptr || _controlBlock->object == nullptr)
             throw std::runtime_error("Object is null or has been destroyed");
 
         return _controlBlock->object;

--- a/CMGT/Scene.cpp
+++ b/CMGT/Scene.cpp
@@ -17,7 +17,10 @@ void Scene::run()
     objectHandler->FixedUpdateAll();
     objectHandler->UpdateAll();
     objectHandler->LateUpdateAll();
+    objectHandler->RenderAll();
     objectHandler->DrawGizmosAll();
+
+    Graphics::Render();
 
     // After full update, destroy all objects
     Application::DestroyPendingObjects();

--- a/CMGT/SpriteRenderer.h
+++ b/CMGT/SpriteRenderer.h
@@ -1,0 +1,27 @@
+#pragma once
+#include "Texture2D.h"
+#include "Component.h"
+#include "Graphics.h"
+
+Script(SpriteRenderer, Component)
+private:
+	sf::Sprite _sprite;
+	Pointer<Texture2D> _texture = nullptr;
+public:
+
+	void Awake() 
+	{
+		_sprite = sf::Sprite();
+	}
+
+	void SetTexture(Pointer<Texture2D> texture)
+	{
+		_sprite.setTexture(*texture->getTexture());
+		_texture = texture;
+	}
+
+	void OnRender()
+	{
+		Graphics::QueueForRendering(&_sprite);
+	}
+};

--- a/CMGT/Texture2D.h
+++ b/CMGT/Texture2D.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include <string>
+#include "Object.h"
+
+class Texture2D : public Object
+{
+private:
+    sf::Texture texture;
+
+public:
+    Texture2D() { }
+
+    Texture2D(const std::string& path)
+    {
+        if (!texture.loadFromFile(path))
+            throw std::runtime_error("Texture was not found");
+    }
+
+    void LoadTexture(const std::string& path)
+    {
+        if (!texture.loadFromFile(path))
+            throw std::runtime_error("Texture was not found");
+    }
+
+    sf::Texture* getTexture()
+    {
+        return &texture;
+    }
+};


### PR DESCRIPTION
### Summary
Implemented a way for sprites to be rendered, will need to be adjusted later to be moved, rotated and scaled, although right now there is no transform just yet

### Changes:
new: Debug tools, added Debug.Log(), Debug.LogError() and Debug.LogWarning(), objects have a default inclusion for Debug.h
new: Texture2D, loads in a sprite on creation, avoids unnecessary double loading
new: SpriteRenderer, renders an sf::sprite, requires a Texture2D as input.

feat: (Crash prevention) ObjectHandler methods like update and start are now wrapped in a Try{}catch{} to avoid total crashing, it also logs the error to the console

feat (Graphics.cpp): added QueueForRendering(sf::sprite), adds it to the render queue and will render it at the end of the frame

Change (Graphics.cpp): Changed Graphics._window from a sf::Window to a sf::RenderWindow

change (component methods): added OnRender() method for components

> [!NOTE]
> In addition to the sprite renderrer i also added Debug::Log, Debug::LogError and Debug::LogWarning methods, removing the use for iostream / std::cout