### PR TITLE
Fixed major memory leak and additional fixes

### DIFF
--- a/CMGT/Component.cpp
+++ b/CMGT/Component.cpp
@@ -10,3 +10,14 @@ Component::Component() :
 {
 
 }
+
+void Component::OnFinalizeDestruction()
+{
+    if (_gameObject != nullptr)
+        _gameObject->RemoveComponent<Component>(Pointer(this));
+
+    if (objectHandler != nullptr)
+        Unregister(objectHandler);
+    _transform = nullptr;
+    _gameObject = nullptr;
+}

--- a/CMGT/Component.h
+++ b/CMGT/Component.h
@@ -17,14 +17,10 @@ public:
     GetSet<Pointer<GameObject>> gameObject;
     GetSet<Pointer<Transform>> transform;
 protected:
-    Pointer<ObjectHandler> objectHandler;
+    Pointer<ObjectHandler> objectHandler = nullptr;
 private:
-    void OnFinalizeDestruction() override 
-    { 
-        Unregister(objectHandler); 
-        _transform = nullptr; 
-        _gameObject = nullptr;
-    }
+    void OnFinalizeDestruction() override;
+
     Pointer<GameObject> _gameObject = nullptr;
     Pointer<Transform> _transform = nullptr;
     virtual void Register(Pointer<ObjectHandler> objectHandler) { };

--- a/CMGT/GameObject.h
+++ b/CMGT/GameObject.h
@@ -17,8 +17,13 @@ private:
 	void OnFinalizeDestruction() final override;
 	void Setup();
 
+	template<typename T>
+	void RemoveComponent(Pointer<T> component);
+
+	friend class Component;
+
 protected:
-	Pointer<ObjectHandler> objectHandler;
+	Pointer<ObjectHandler> objectHandler = nullptr;
 	Pointer<Transform> _transform = nullptr;
 
 public:
@@ -35,6 +40,21 @@ public:
 	template<typename T>
 	std::vector<Component> GetComponents();
 };
+
+template<typename T>
+void GameObject::RemoveComponent(Pointer<T> component)
+{
+	static_assert(std::is_base_of<Component, T>::value, "T must derive from Component");
+	for (auto it = _components.begin(); it != _components.end(); ++it)
+	{
+		if (*it != component)
+			continue;
+
+		_components.erase(it);
+		break;
+	}
+}
+
 
 template<typename T>
 Pointer<T> GameObject::AddComponent()

--- a/CMGT/Object.cpp
+++ b/CMGT/Object.cpp
@@ -7,11 +7,15 @@
 void Object::FinalizeDestruction()
 {
     OnFinalizeDestruction();
-    if (_controlBlock)
-        _controlBlock->OnObjectDestroyed();
 }
 
 void Object::CueForDestruction()
 {
     Application::QueueNewDestructable(Pointer<Object>(this));
+}
+
+Object::~Object()
+{
+    if (_controlBlock != nullptr)
+        _controlBlock->OnObjectDestroyed();
 }

--- a/CMGT/Object.h
+++ b/CMGT/Object.h
@@ -63,9 +63,9 @@ public:
     static void DestroyImmediate(Pointer<T> other)
     {
         static_assert(std::is_base_of<Object, T>::value, "Type must be an object");
-        T* original = other.Get();
         other->FinalizeDestruction();
-        delete original;
+        delete other.Get();
     }
+    virtual ~Object();
 };
 

--- a/CMGT/PointerControlBlock.h
+++ b/CMGT/PointerControlBlock.h
@@ -16,24 +16,27 @@ public:
 
     void ReleaseRef()
     {
-        if (--ref_count <= 0 && object != nullptr)
+        if (--ref_count <= 0)
         {
-            T* temp = object;
-            object = nullptr;
-            delete(object);
+            if (object != nullptr)
+            {
+                T* temp = object;
+                object = nullptr;
+                delete(object);
+            }
+            delete(this);
         }
     }
 
     void OnObjectDestroyed()
     {
         object = nullptr;
-        ref_count = 0;
-        if (object != nullptr)
-            delete(object);
     }
 
     ~ControlBlock()
     {
         OnObjectDestroyed();
+        if (object != nullptr)
+            delete(object);
     }
 };


### PR DESCRIPTION
### Summary
Fixed a major and a minor memory leak, which were caused by the static_pointer_cast method creating a completely new object and not disposing of it properly, as well as the PointerControlBlock, which would never be destroyed as there was nothing keeping proper track of wether or not it should remain

### Changes
- Fix (Component): Component will remove itself from its gameObject when destroyed
- Fix (Runtime objects): Components and GameObjects will default their objectHandler to null in order to avoid unnecessary creation and destruction of object handlers.
- Fix (Memory management): Fixed a memory leak by telling the staticPointerCast method to create an empty pointer instead of a new one
- Fix (Memory management): Made PointerControlBlock delete itself when no references remained, as there was nothing removing it before.