### PR TITLE
Fixed pointer

### DIFF
--- a/CMGT/Pointer.h
+++ b/CMGT/Pointer.h
@@ -38,9 +38,18 @@ public:
     Pointer()
     {
         static_assert(!std::is_abstract<T>::value, "Type cannot be abstract");
-        T* obj = new T();
-        _controlBlock = new ControlBlock<T>(obj);
-        obj->_controlBlock = reinterpret_cast<ControlBlock<Object>*>(_controlBlock);
+        T* p = new T();
+
+        if (!p->_controlBlock)
+        {
+            _controlBlock = new ControlBlock<T>(p);
+            p->_controlBlock = reinterpret_cast<ControlBlock<Object>*>(_controlBlock);
+        }
+        else
+        {
+            _controlBlock = reinterpret_cast<ControlBlock<T>*>(p->_controlBlock);
+            _controlBlock->AddRef();
+        }
     }
 
     Pointer(std::nullptr_t) : _controlBlock(nullptr) { }


### PR DESCRIPTION
### Summary
There was a bug where if you nested objects outside of the scene script it would break when trying to destroy it as it was creating a new pointer control block  overriding the one attatched to the transform. 

It would basically create a new object T, which in its own constructor would give it a pointer control block and use that for the transform, and after that the pointer constructor would override it with its own control block, so if you were to call destroy(), and the original pointer went out of the scope then there would no longer be any pointers to the new control block, making it unusable. 

### Changes
- Fix (Control block creation): made it so Pointer constructor only creates a new control block if there wasnt one assigned yet in the objects constructor itself